### PR TITLE
Pkg 4693 graphql-relay 3.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
   run:
     - python
     - graphql-core >=3.2,<3.3
-    - typing_extensions >=4.1,<5  # [py<38]
+    - typing_extensions >=4.1  # [py<38]
 
 test:
   source_files:
@@ -46,6 +46,10 @@ about:
   license: MIT
   license_family: MIT
   summary: Relay library for graphql-core
+  description: |
+    A library to help construct a graphql-py server supporting react-relay
+  dev_url: https://github.com/graphql-python/graphql-relay-py
+  doc_url: https://github.com/graphql-python/graphql-relay-py/blob/main/README.md
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,17 +23,17 @@ requirements:
   run:
     - python
     - graphql-core >=3.2,<3.3
-    - typing_extensions >=4.1  # [py<38]
+    - typing_extensions >=4.1,<5  # [py<38]
 
 test:
   source_files:
     - tests
   requires:
     - pip
-    - pytest >=6.2
+    - pytest >=6.2,<7
     - pytest-asyncio >=0.18,<1
-    - pytest-cov >=3.0
-    - pytest-describe >=2.0
+    - pytest-cov >=3.0,<4.0
+    - pytest-describe >=2.0,<3.0
   imports:
     - graphql_relay
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install -vv .
+  script: {{ PYTHON }} -m pip install -vv . --no-deps --no-build-isolation
   skip: True  # [py<36]
 
 requirements:
@@ -34,7 +34,6 @@ test:
     - pytest-asyncio >=0.18,<1
     - pytest-cov >=3.0
     - pytest-describe >=2.0
-    - pyyaml >=5.4,<6
   imports:
     - graphql_relay
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,10 +18,12 @@ requirements:
     - pip
     - python >=3.6
     - poetry-core >=1,<2
+    - setuptools >=59,<70
+    - wheel
   run:
     - python >=3.6
     - graphql-core >=3.2,<3.3
-    - typing_extensions >=4.1,<5
+    - typing_extensions >=4.1,<5  # [py<38]
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,9 +31,9 @@ test:
   requires:
     - pip
     - pytest >=6.2,<7
-    - pytest-asyncio >=0.14,<1
-    - pytest-cov >=2.11,<3
-    - pytest-describe >=1,<2
+    - pytest-asyncio >=0.18,<1
+    - pytest-cov >=3.0
+    - pytest-describe >=2.0
     - pyyaml >=5.4,<6
   imports:
     - graphql_relay

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ test:
     - tests
   requires:
     - pip
-    - pytest >=6.2,<7
+    - pytest >=6.2
     - pytest-asyncio >=0.18,<1
     - pytest-cov >=3.0
     - pytest-describe >=2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,19 +9,19 @@ source:
   sha256: 1ff1c51298356e481a0be009ccdff249832ce53f30559c1338f22a0e0d17250c
 
 build:
-  noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install -vv .
+  skip: True  # [py<36]
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
     - poetry-core >=1,<2
     - setuptools >=59,<70
     - wheel
   run:
-    - python >=3.6
+    - python
     - graphql-core >=3.2,<3.3
     - typing_extensions >=4.1,<5  # [py<38]
 


### PR DESCRIPTION
graphql-relay 3.2.0

**Destination channel:** {defaults}

### Links

- [PKG-4693](https://anaconda.atlassian.net/browse/PKG-4693) 
- [Upstream repository](https://github.com/graphql-python/graphql-relay-py)
- Relevant dependency PRs:
  - [pytest-describe](https://github.com/AnacondaRecipes/pytest-describe-feedstock/pull/4)

### Explanation of changes:

- Add new submodule needed for [`graphene`](https://github.com/AnacondaRecipes/graphene-feedstock/pull/2) > [`mlflow`](https://github.com/AnacondaRecipes/mlflow-feedstock/pull/6)


[PKG-4693]: https://anaconda.atlassian.net/browse/PKG-4693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ