### PR TITLE
graphql-relay 3.2.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -2,4 +2,4 @@ build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313: yes
 
 channels:
-- https://staging.continuum.io/prefect/fs/pytest-benchmark-feedstock/pr6/41a08f5
+- https://staging.continuum.io/prefect/fs/graphql-core-feedstock/pr6/fd2b2fc

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313: yes
-
-channels:
-- https://staging.continuum.io/prefect/fs/graphql-core-feedstock/pr6/fd2b2fc

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes
+
+channels:
+- https://staging.continuum.io/prefect/fs/pytest-benchmark-feedstock/pr6/41a08f5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - pip
     - python
     - poetry-core >=1,<2
-    - setuptools >=59,<70
+    - setuptools >=59
     - wheel
   run:
     - python
@@ -41,7 +41,7 @@ test:
     - pytest --cov graphql_relay --no-cov-on-fail --cov-report term-missing:skip-covered --cov-fail-under 91
 
 about:
-  home: https://github.com/graphql-python/graphql-relay-py
+  home: https://github.com/theacodes/cmarkgfm
   license_file: LICENSE
   license: MIT
   license_family: MIT

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ test:
     - pytest --cov graphql_relay --no-cov-on-fail --cov-report term-missing:skip-covered --cov-fail-under 91
 
 about:
-  home: https://github.com/theacodes/cmarkgfm
+  home: https://github.com/graphql-python/graphql-relay-py
   license_file: LICENSE
   license: MIT
   license_family: MIT


### PR DESCRIPTION
graphql-relay 3.2.0 

**Destination channel:** Defaults

### Links

- [PKG-7139]
- dev_url:        https://github.com/graphql-python/graphql-relay-py/tree/v3.2.0
- conda_forge:    https://github.com/conda-forge/graphql-relay-feedstock
- pypi:           https://pypi.org/project/graphql-relay/3.2.0
- pypi inspector: https://inspector.pypi.io/project/graphql-relay/3.2.0

### Explanation of changes:

- new version number


[PKG-7139]: https://anaconda.atlassian.net/browse/PKG-7139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ